### PR TITLE
List of Previous Order Is Now User-Specific

### DIFF
--- a/browser/js/checkout/checkout.js
+++ b/browser/js/checkout/checkout.js
@@ -27,7 +27,7 @@ app.controller('CheckoutCtrl', function ($scope, $http, cartInfo, $state) {
 		$http.post('/api/checkout', {cartInfo: cartInfo}).
 			success(function(data) {
 			    console.log("Order created!");
-			    $state.go('home');
+			    $state.go('confirmation');
 			}).
 			error(function(data) {
 			    console.log("Error creating order!");

--- a/browser/js/login/login.js
+++ b/browser/js/login/login.js
@@ -17,8 +17,6 @@ app.controller('LoginCtrl', function ($scope, AuthService, $state, $rootScope) {
 
         $scope.error = null;
 
-        console.log('BAH',$rootScope.previousState)
-
         AuthService.login(loginInfo).then(function () {
             $state.go($rootScope.previousState);
         }).catch(function () {

--- a/browser/js/orders/orders.js
+++ b/browser/js/orders/orders.js
@@ -7,8 +7,9 @@ app.config(function ($stateProvider) {
 		templateUrl: 'js/orders/orders.html',
 		controller: 'OrdersCtrl',
 		resolve: {
-			orderInfo: function (ordersFactory) {
-				return ordersFactory.getOrders("5541421a6c6c31d47876e032");
+			orderInfo: function (ordersFactory, Session) {
+				var userId = Session.user._id;
+				return ordersFactory.getOrders(userId);
 			}
 		}
 	});

--- a/server/app/routes/cart/index.js
+++ b/server/app/routes/cart/index.js
@@ -18,10 +18,15 @@ router.get('/', function (req, res) {
 	cartModel.findOne({sessionId: sessionId}).exec(function (err, cart) {
 		if(err) throw err;
 
-		lineItemModel.populate(cart.lineItems, opts, function(err, populatedLineItem) {
-			if(err) throw err;
-			res.send(cart);
-		}) 
+		if (cart) {
+			lineItemModel.populate(cart.lineItems, opts, function(err, populatedLineItem) {
+				if(err) throw err;
+				res.send(cart);
+			});
+		} else {
+			console.log("NO CART FOUND!");
+			throw err;
+		}
 
 	});
 

--- a/server/app/routes/checkout/index.js
+++ b/server/app/routes/checkout/index.js
@@ -1,5 +1,7 @@
 'use strict';
 var mongoose = require('mongoose');
+var cartModel = mongoose.model('Cart');
+
 var router = require('express').Router();
 module.exports = router;
 
@@ -10,28 +12,27 @@ var orderModel = mongoose.model('Order');
 router.post('/', function (req, res, next) {
 	var cartId = req.body.cartInfo._id;
 	var sessionId = req.sessionID;
+	var userId = req.user._id;
 
 	// Function to generate a random confirmation number
 
 	// It should create an order that includes the line items
 
-	console.log("The cartId is ", cartId);
-
 	cartModel.findOne({_id: cartId}).exec(function (err, currentCart) {
 		if (err) throw err;
 
-		console.log("The currentCart is ", currentCart);
+		// Generate random confirmationNumber for current Order
+
+		var confirmationNumber = Math.random().toString(36).slice(2);
 
 		var order = new orderModel({
 			sessionId: sessionId,
 			status: "Active",
-			user: "5541421a6c6c31d47876e032",
+			user: userId,
 			datetime: new Date().getTime(),
-			confirmationNumber: "12345678",
+			confirmationNumber: confirmationNumber,
 			lineItems: currentCart.lineItems,
 		});
-
-		console.log(order);
 
 		order.save();
 	});
@@ -40,11 +41,37 @@ router.post('/', function (req, res, next) {
 		console.log(cart);
 		if(err) throw err;
 		cart.closed = true;
+		cart.user = userId;
 		cart.save();
 	});
 
-	res.sendStatus(200);
 
 	// It should generate a new session (in order to load a new cart)
+
+	console.log("OLD SESSION ID", req.sessionID);
+
+	//  Save the current session state before I regenerate the sessionID
+    var temp = req.session.passport; // {user: 1}
+
+    req.session.regenerate(function(err){
+        //req.session.passport is now undefined, so let's reset it
+        req.session.passport = temp;
+		var newSessionId = req.sessionID;
+		console.log("NEW SESSION ID", req.sessionID);
+
+        //Create the new cart
+        var cart = new cartModel({
+        	sessionId: newSessionId,
+        	promoApplied: false,
+        	user: userId
+        });
+
+        cart.save();
+
+        req.session.save(function(err){
+    		if(err) throw err;
+			res.sendStatus(200);
+        });
+    });
 
 });

--- a/server/db/models/cart.js
+++ b/server/db/models/cart.js
@@ -7,6 +7,7 @@ var lineItemSchema = new mongoose.Schema({
 
 var cartSchema = new mongoose.Schema({
 	lineItems: [lineItemSchema],
+	user: {type:mongoose.Schema.Types.ObjectId, ref: 'User'},
 	sessionId: {type: String, required: true},
 	promoApplied: {type: Boolean, required: true}, 
 	promoDiscount: {type: Number, required: true, default: 0},


### PR DESCRIPTION
By injecting the `Session` service, you are able to access the current `userID`. With this, we can fetch the list of orders from the database that is unique to the current user :sake:.

Should merge https://github.com/carolynyoo/stack_store/pull/109 first.

Demo here:
![previous-orders-depends-on-current-user](https://cloud.githubusercontent.com/assets/2261842/7440146/b287fd68-f03d-11e4-8ac6-d4929f6316da.gif)
