### PR TITLE
List of Previous Order Is Now User-Specific

### DIFF
--- a/browser/js/orders/orders.js
+++ b/browser/js/orders/orders.js
@@ -7,8 +7,10 @@ app.config(function ($stateProvider) {
 		templateUrl: 'js/orders/orders.html',
 		controller: 'OrdersCtrl',
 		resolve: {
-			orderInfo: function (ordersFactory) {
-				return ordersFactory.getOrders("5541421a6c6c31d47876e032");
+				orderInfo: function (ordersFactory, Session) {
+				var userId = Session.user._id;
+				return ordersFactory.getOrders(userId);
+				}
 			}
 		}
 	});


### PR DESCRIPTION
By injecting the `Session` service, you are able to access the current `userID`. With this, we can fetch the list of orders from the database that is unique to the current user :sake:.

Demo here:
![previous-orders-depends-on-current-user](https://cloud.githubusercontent.com/assets/2261842/7440146/b287fd68-f03d-11e4-8ac6-d4929f6316da.gif)
